### PR TITLE
[BC BREAK] emails persisted between reboots

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.yml]
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -9,9 +9,12 @@ an alternative to the FrameworkBundle's `MailerAssertionsTrait`.
 
 ## Installation
 
-```bash
-composer require --dev zenstruck/mailer-test
-```
+1. Install the library:
+    ```bash
+    composer require --dev zenstruck/mailer-test
+    ```
+2. If not added automatically by symfony/flex, enable `ZenstruckMailerTestBundle` in your
+   `test` environment
 
 ## Usage
 
@@ -62,11 +65,13 @@ class MyTest extends KernelTestCase // or WebTestCase
             // Any \Symfony\Component\Mime\Email methods can be used
             $this->assertSame('value', $email->getHeaders()->get('X-SOME-HEADER')->getBodyAsString());
         });
-        
+
         $this->mailer()->sentTestEmails(); // TestEmail[]
     }
 }
 ```
+
+**NOTE**: Emails are persisted between kernel reboots within each test.
 
 ### Custom TestEmail
 
@@ -143,7 +148,7 @@ $browser
     ->use(function(MailerComponent $component) {
         $component->assertNoEmailSent();
     })
-    
+
     ->withProfiling() // enable the profiler for the next request
     ->visit('/page/that/sends/email')
     ->use(function(MailerComponent $component) {
@@ -188,7 +193,7 @@ $browser
     ->withProfiling() // enable the profiler for the next request
     ->visit('/page/that/does/not/send/email')
     ->assertNoEmailSent()
-    
+
     ->withProfiling() // enable the profiler for the next request
     ->visit('/page/that/sends/email')
     ->assertSentEmailCount(1)

--- a/src/MessageEventCollector.php
+++ b/src/MessageEventCollector.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Zenstruck\Mailer\Test;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Mailer\Event\MessageEvent;
+use Symfony\Component\Mailer\Event\MessageEvents;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @internal
+ */
+final class MessageEventCollector implements EventSubscriberInterface
+{
+    private static ?MessageEvents $events = null;
+
+    public function onMessage(MessageEvent $event): void
+    {
+        if (self::$events) {
+            self::$events->add($event);
+        }
+    }
+
+    public function mailer(): TestMailer
+    {
+        if (!self::$events) {
+            throw new \LogicException('Cannot access mailer as email collection has not yet been started.');
+        }
+
+        return new TestMailer(self::$events);
+    }
+
+    public static function start(): void
+    {
+        self::$events = new MessageEvents();
+    }
+
+    public static function reset(): void
+    {
+        self::$events = null;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            MessageEvent::class => ['onMessage', -255],
+        ];
+    }
+}

--- a/src/ZenstruckMailerTestBundle.php
+++ b/src/ZenstruckMailerTestBundle.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Zenstruck\Mailer\Test;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ZenstruckMailerTestBundle extends Bundle
+{
+    public function build(ContainerBuilder $container): void
+    {
+        $container->register('zenstruck_mailer_test.event_collector', MessageEventCollector::class)
+            ->addTag('kernel.event_subscriber')
+        ;
+    }
+
+    public function getContainerExtension(): ?ExtensionInterface
+    {
+        return null;
+    }
+}

--- a/tests/Fixture/Kernel.php
+++ b/tests/Fixture/Kernel.php
@@ -9,6 +9,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 use Symfony\Component\Routing\RouteCollectionBuilder;
+use Zenstruck\Mailer\Test\ZenstruckMailerTestBundle;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -32,6 +33,10 @@ final class Kernel extends BaseKernel
     public function registerBundles(): iterable
     {
         yield new FrameworkBundle();
+
+        if ('no_bundle' !== $this->environment) {
+            yield new ZenstruckMailerTestBundle();
+        }
     }
 
     protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader): void

--- a/tests/Fixture/config/no_bundle.yaml
+++ b/tests/Fixture/config/no_bundle.yaml
@@ -1,0 +1,2 @@
+imports:
+  - { resource: test.yaml }

--- a/tests/Fixture/config/no_mailer.yaml
+++ b/tests/Fixture/config/no_mailer.yaml
@@ -1,8 +1,0 @@
-framework:
-    secret: S3CRET
-    router: { utf8: true }
-    test: true
-    profiler:
-        collect: false
-    messenger: false
-    mailer: false

--- a/tests/NonInteractsWithMailerTest.php
+++ b/tests/NonInteractsWithMailerTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Zenstruck\Mailer\Test\Tests;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Mailer\Test\Tests\Fixture\Email1;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class NonInteractsWithMailerTest extends KernelTestCase
+{
+    /**
+     * @test
+     */
+    public function ensure_emails_are_not_collected(): void
+    {
+        self::bootKernel();
+
+        self::$container->get('mailer')->send(new Email1());
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Cannot access mailer as email collection has not yet been started.');
+
+        self::$container->get('zenstruck_mailer_test.event_collector')->mailer();
+    }
+}


### PR DESCRIPTION
Closes #5.

**BC BREAKS**
1. For each test in a test case using `InteractsWithMailer`, emails are now persisted between kernel reboots. This will cause BC breaks for tests that have kernel reboots (ie using `zenstruck/browser`) and checking emails multiple times.
2. A lightweight bundle is now included and required. If this package is already installed in your app, when you upgrade, `symfony/flex` will not enable this bundle and you'll have to do this manually.