### PR TITLE
`TestEmail::assertHasFile()` improvements

### DIFF
--- a/src/TestEmail.php
+++ b/src/TestEmail.php
@@ -236,8 +236,11 @@ class TestEmail
     /**
      * @return static
      */
-    final public function assertHasFile(string $expectedFilename, string $expectedContentType, string $expectedContents): self
-    {
+    final public function assertHasFile(
+        string $expectedFilename,
+        ?string $expectedContentType = null,
+        ?string $expectedContents = null
+    ): self {
         foreach ($this->email->getAttachments() as $attachment) {
             /** @var ParameterizedHeader $header */
             $header = $attachment->getPreparedHeaders()->get('content-disposition');
@@ -246,7 +249,15 @@ class TestEmail
                 continue;
             }
 
-            Assert::that($attachment->getBody())->is($expectedContents);
+            Assert::pass();
+
+            if ($expectedContents) {
+                Assert::that($attachment->getBody())->is($expectedContents);
+            }
+
+            if (!$expectedContentType) {
+                return $this;
+            }
 
             /** @var ParameterizedHeader $header */
             $header = $attachment->getPreparedHeaders()->get('content-type');

--- a/src/TestEmail.php
+++ b/src/TestEmail.php
@@ -251,9 +251,7 @@ class TestEmail
             /** @var ParameterizedHeader $header */
             $header = $attachment->getPreparedHeaders()->get('content-type');
 
-            Assert::that($header->getBodyAsString())
-                ->is($expectedContentType.'; name='.$expectedFilename)
-            ;
+            Assert::that($header->getValue())->is($expectedContentType);
 
             return $this;
         }

--- a/tests/Fixture/Email1.php
+++ b/tests/Fixture/Email1.php
@@ -32,6 +32,7 @@ final class Email1 extends Email
             ->bcc('bcc@example.com')
             ->replyTo('reply@example.com')
             ->attachFromPath(__DIR__.'/files/attachment.txt')
+            ->attachFromPath(__DIR__.'/files/attachment.txt', 'name with space.txt')
             ->subject('email subject')
             ->html('html body')
             ->text('text body')

--- a/tests/InteractsWithMailerTest.php
+++ b/tests/InteractsWithMailerTest.php
@@ -76,6 +76,8 @@ final class InteractsWithMailerTest extends KernelTestCase
                     ->assertHtmlContains('html body')
                     ->assertTextContains('text body')
                     ->assertContains('body')
+                    ->assertHasFile('attachment.txt')
+                    ->assertHasFile('attachment.txt', 'text/plain')
                     ->assertHasFile('attachment.txt', 'text/plain', "attachment contents\n")
                     ->assertHasFile('name with space.txt', 'text/plain', "attachment contents\n")
                 ;

--- a/tests/InteractsWithMailerTest.php
+++ b/tests/InteractsWithMailerTest.php
@@ -77,6 +77,7 @@ final class InteractsWithMailerTest extends KernelTestCase
                     ->assertTextContains('text body')
                     ->assertContains('body')
                     ->assertHasFile('attachment.txt', 'text/plain', "attachment contents\n")
+                    ->assertHasFile('name with space.txt', 'text/plain', "attachment contents\n")
                 ;
 
                 // TestEmail can call underlying Symfony\Component\Mime\Email methods


### PR DESCRIPTION
Fixes #19.

When quotes are surrounding the filename, the assertion failed but shouldn't.