### PR TITLE
feat: allow symfony 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # CHANGELOG
 
-## [v1.4.3](https://github.com/zenstruck/mailer-test/releases/tag/v1.4.3)
-* 7d539f6 feat: Symfony 8 support
-
 ## [v1.4.2](https://github.com/zenstruck/mailer-test/releases/tag/v1.4.2)
 
 August 15th, 2024 - [v1.4.1...v1.4.2](https://github.com/zenstruck/mailer-test/compare/v1.4.1...v1.4.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## [v1.4.3](https://github.com/zenstruck/mailer-test/releases/tag/v1.4.3)
+* 7d539f6 feat: Symfony 8 support
+
 ## [v1.4.2](https://github.com/zenstruck/mailer-test/releases/tag/v1.4.2)
 
 August 15th, 2024 - [v1.4.1...v1.4.2](https://github.com/zenstruck/mailer-test/compare/v1.4.1...v1.4.2)

--- a/composer.json
+++ b/composer.json
@@ -13,18 +13,18 @@
     ],
     "require": {
         "php": ">=8.0",
-        "symfony/framework-bundle": "^5.4|^6.0|^7.0",
-        "symfony/mailer": "^5.4|^6.0|^7.0",
+        "symfony/framework-bundle": "^5.4|^6.0|^7.0|^8.0",
+        "symfony/mailer": "^5.4|^6.0|^7.0|^8.0",
         "zenstruck/assert": "^1.0",
         "zenstruck/callback": "^1.1"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.4",
         "phpunit/phpunit": "^9.6.21",
-        "symfony/messenger": "^5.4|^6.0|^7.0",
-        "symfony/phpunit-bridge": "^6.0|^7.0",
-        "symfony/var-dumper": "^5.4|^6.0|^7.0",
-        "symfony/yaml": "^5.4|^6.0|^7.0",
+        "symfony/messenger": "^5.4|^6.0|^7.0|^8.0",
+        "symfony/phpunit-bridge": "^6.0|^7.0|^8.0",
+        "symfony/var-dumper": "^5.4|^6.0|^7.0|^8.0",
+        "symfony/yaml": "^5.4|^6.0|^7.0|^8.0",
         "zenstruck/browser": "^1.0"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^1.4",
         "phpunit/phpunit": "^9.6.21",
+        "symfony/console": "^5.4|^6.0|^7.0|^8.0",
         "symfony/messenger": "^5.4|^6.0|^7.0|^8.0",
         "symfony/phpunit-bridge": "^6.0|^7.0|^8.0",
         "symfony/var-dumper": "^5.4|^6.0|^7.0|^8.0",


### PR DESCRIPTION
"zenstruck/browser" does not yet support symfony 8
i need to check if symfony 8 is already covered by ci

Blocked by:
- https://github.com/zenstruck/browser/pull/184